### PR TITLE
Strip comments from dependency declaration blocks before JSON parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,19 +39,21 @@ myfile.init(); // Outputs A new run definition
 
 ## Options
 
-To customize options (currently only one option is supported), add a `amdInjectLoader` key to your webpack config file:
+To customize options, add a `amdInjectLoader` key to your webpack config file:
 
 ```js
 {
 	loaders: [ ... ],
 	...
 	amdInjectLoader: {
-		istanbul: true
+		istanbul: true,
+		stripComments: true
 	}
 }
 ```
 
 * **`istanbul`** - `true` or `false` (Defaults to `false`) – Include istanbul ignore blocks on the lines that handle the injection
+* **`stripComments`** - `true` or `false` (Defaults to `false`) – Strip comments from multiline dependency declarations
 
 
 [Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ module.exports = function( input ) {
 
 	var options = this.options.amdInjectLoader || {};
 	var istanbul = options.istanbul === true;
+	var stripComments = options.stripComments === true;
 
 	// Match AMD define and function
 	var rCapture = /define\([ ]?(\[[\s\S]*?\]),[ ]?function[ ]?\(([^)]+)?\)[ ]?{/;
@@ -11,8 +12,17 @@ module.exports = function( input ) {
 	if ( !matched ) {
 		throw new Error( "The amd-inject-loader only supports AMD files with dependencies." );
 	}
+	var rawDependencies = matched[ 1 ];
 
-	var dependencies = JSON.parse( matched[ 1 ].replace( /'/g, "\"" ) );
+	if ( stripComments ) {
+		rawDependencies = rawDependencies.replace(/\/\/.+/ig, '');
+	}
+
+	try {
+		var dependencies = JSON.parse( rawDependencies.replace( /'/g, "\"" ) );
+	} catch (e) {
+		throw new Error( "JSON parsing failed in amd-inject-loader." );
+	}
 	var args = ( matched[ 2 ] || "" ).trim().split( /,[ ]?/g );
 
 	var injectorCode = [];

--- a/spec/examples/multilineWithComments.js
+++ b/spec/examples/multilineWithComments.js
@@ -1,0 +1,9 @@
+define( [
+	// libs
+	"lodash",
+	"jquery", // jquery
+	// app code, dependency
+	"app/code"
+], function( _, appcode ) {
+		_.each( [ 1, 2, 3 ], console.log.bind( console ) );
+	} );

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -46,6 +46,28 @@ describe( "amd-inject-loader", function() {
 		stub.calledOnce.should.be.ok;
 		stub.calledWith( [ 1, 2, 3 ] ).should.be.ok;
 	} );
+	it( "should tranform the file correctly even when define has comments", function() {
+		var localEr = require( "enhanced-require" )( module, {
+			amdInjectLoader: {
+				stripComments: false
+			}
+		} );
+		var factory = localEr( "../index.js!./examples/multilineWithComments" );
+		var resp = factory.toString();
+
+		resp.should.match( /var _ =/ );
+
+		var stub = sinon.stub();
+
+		factory( {
+			"lodash": { each: stub },
+			"jquery": { each: stub },
+			"app/code": { each: stub }
+		} );
+
+		stub.calledOnce.should.be.ok;
+		stub.calledWith( [ 1, 2, 3 ] ).should.be.ok;
+	} );
 
 	it( "should allow the factory method to be called without any arguments", function() {
 		var factory = er( "../index.js!./examples/withInclude" );

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -49,7 +49,7 @@ describe( "amd-inject-loader", function() {
 	it( "should tranform the file correctly even when define has comments", function() {
 		var localEr = require( "enhanced-require" )( module, {
 			amdInjectLoader: {
-				stripComments: false
+				stripComments: true
 			}
 		} );
 		var factory = localEr( "../index.js!./examples/multilineWithComments" );


### PR DESCRIPTION
If the `stripComments` options is set to true parse out comments from the declaration block string, to allow the JSON parser processing the string.
Additionally, if the JSON parser fails it'll throw an error now, to make debugging easier.
