### PR TITLE
Support named modules.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ module.exports = function( input ) {
 	var stripComments = options.stripComments === true;
 
 	// Match AMD define and function
-	var rCapture = /define\([ ]?(\[[\s\S]*?\]),[ ]?function[ ]?\(([^)]+)?\)[ ]?{/;
+	var rCapture = /define\((?:[ ]?[^,]*,)?[ ]?(\[[\s\S]*?\]),[ ]?function[ ]?\(([^)]+)?\)[ ]?{/;
+
 	var matched = rCapture.exec( input );
 
 	if ( !matched ) {

--- a/spec/examples/simpleNamed.js
+++ b/spec/examples/simpleNamed.js
@@ -1,0 +1,3 @@
+define( 'simple/named/module', [ "lodash" ], function( _ ) {
+    _.each( [ 1, 2, 3 ], console.log.bind( console ) );
+} );

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -37,6 +37,22 @@ describe( "amd-inject-loader", function() {
 		stub.calledWith( [ 1, 2, 3 ] ).should.be.ok;
 	} );
 
+	it( "should transform the file correctly when the module is named", function() {
+		var factory = er( "../index.js!./examples/simpleNamed" );
+		var resp = factory.toString();
+
+		resp.should.match( /var _ =/ );
+
+		var stub = sinon.stub();
+
+		factory( {
+			"lodash": { each: stub }
+		} );
+
+		stub.calledOnce.should.be.ok;
+		stub.calledWith( [ 1, 2, 3 ] ).should.be.ok;
+	} );
+
 	it( "should tranform the file correctly even when define is multiline", function() {
 		var factory = er( "../index.js!./examples/multiline" );
 		var resp = factory.toString();


### PR DESCRIPTION
In converting a require.js project to webpack, I discovered that this loader does not recognize require.js style named modules, which is what this old project is entirely composed of. Webpack does support this style, for modules not referenced outside the bundle, so I would advocate for the loader supporting it as well.

This PR adds a tolerance for the optional leading string argument before the dependency list of a define call. It includes a new spec and example file for this scenario as well.
