### PR TITLE
Already instrumented code can be injected also

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,14 +8,14 @@ module.exports = function( input ) {
 	var stripComments = options.stripComments === true;
 
 	// Match AMD define and function
-	var rCapture = /define\((?:[ ]?[^,]*,)?[ ]?(\[[\s\S]*?\]),[ ]?function[ ]?\(([^)]+)?\)[ ]?{/;
+	var rCapture = /(^|;)\s*define\((?:[ ]?[^,]*,)?[ ]?(\[[\s\S]*?\]),[ ]?function[ ]?\(([^)]+)?\)[ ]?{/m;
 
 	var matched = rCapture.exec( input );
 
 	if ( !matched ) {
 		throw new Error( "The amd-inject-loader only supports AMD files with dependencies." );
 	}
-	var rawDependencies = matched[ 1 ];
+	var rawDependencies = matched[ 2 ];
 
 	if ( stripComments ) {
 		rawDependencies = rawDependencies.replace(/\/\/.+/ig, '');
@@ -26,7 +26,7 @@ module.exports = function( input ) {
 	} catch (e) {
 		throw new Error( "JSON parsing failed in amd-inject-loader." );
 	}
-	var args = ( matched[ 2 ] || "" ).trim().split( /,[ ]?/g );
+	var args = ( matched[ 3 ] || "" ).trim().split( /,[ ]?/g );
 
 	var injectorCode = [];
 
@@ -44,7 +44,7 @@ module.exports = function( input ) {
 	} );
 
 	// Swap out define call with new injection style
-	input = input.replace( rCapture, "module.exports = ( function ( injections ) { \n\t" + injectorCode.join( "\n\t" ) );
+	input = input.replace( rCapture, matched[1] + "module.exports = ( function ( injections ) { \n\t" + injectorCode.join( "\n\t" ) );
 
 	return input;
 };

--- a/spec/examples/instrumented.js
+++ b/spec/examples/instrumented.js
@@ -1,0 +1,8 @@
+var __cov_lepKfuR3B6UrskX3Xk4$8Q = (Function('return this'))();
+if (!__cov_lepKfuR3B6UrskX3Xk4$8Q.__coverage__) { __cov_lepKfuR3B6UrskX3Xk4$8Q.__coverage__ = {}; }
+__cov_lepKfuR3B6UrskX3Xk4$8Q = __cov_lepKfuR3B6UrskX3Xk4$8Q.__coverage__;
+if (!(__cov_lepKfuR3B6UrskX3Xk4$8Q['C:\\workspace\\external\\amd-inject-loader\\spec\\examples\\instrumented.js'])) {
+	__cov_lepKfuR3B6UrskX3Xk4$8Q['C:\\workspace\\external\\amd-inject-loader\\spec\\examples\\instrumented.js'] = {"path":"C:\\workspace\\external\\amd-inject-loader\\spec\\examples\\instrumented.js","s":{"1":0,"2":0},"b":{},"f":{"1":0},"fnMap":{"1":{"name":"(anonymous_1)","line":3,"loc":{"start":{"line":3,"column":3},"end":{"line":3,"column":17}}}},"statementMap":{"1":{"start":{"line":1,"column":0},"end":{"line":5,"column":4}},"2":{"start":{"line":4,"column":1},"end":{"line":4,"column":52}}},"branchMap":{}};
+		}
+		__cov_lepKfuR3B6UrskX3Xk4$8Q = __cov_lepKfuR3B6UrskX3Xk4$8Q['C:\\workspace\\external\\amd-inject-loader\\spec\\examples\\instrumented.js'];
+	__cov_lepKfuR3B6UrskX3Xk4$8Q.s['1']++;define(['lodash'],function(_){__cov_lepKfuR3B6UrskX3Xk4$8Q.f['1']++;__cov_lepKfuR3B6UrskX3Xk4$8Q.s['2']++;_.each([1,2,3],console.log.bind(console));});

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -128,4 +128,19 @@ describe( "amd-inject-loader", function() {
 		lines[ 3 ].should.equal( "\t/* istanbul ignore next - the following line of code is used for dependency injection */" );
 		lines[ 4 ].should.startWith( "\tvar React =" );
 	} );
+
+	it( "should support transformation of istanbul instrumented code", function() {
+		var factory = er( "../index.js!./examples/instrumented" );
+
+		var stub = sinon.stub();
+
+		factory( {
+			"lodash": { each: stub }
+		} );
+
+		stub.calledOnce.should.be.ok;
+		stub.calledWith( [ 1, 2, 3 ] ).should.be.ok;
+	} );
+
+
 } );


### PR DESCRIPTION
As one possible configuration of Webpack with Istanbul includes https://github.com/deepsweet/istanbul-instrumenter-loader as a **preLoader**, it's important that the injection mechanism can work on already instrumented code.
